### PR TITLE
Fix channels filenames

### DIFF
--- a/dcp_inspect
+++ b/dcp_inspect
@@ -562,7 +562,7 @@ def audio_characteristics( ramdisk, asset_file, channel_count, entry_point, dura
   fifo_tokens = Array.new
   asdcp_prefix_token = File.join( ramdisk.path, 'asdcp-temp-audio' )
   ( 1 .. channel_count ).each do |ch|
-    fifo_tokens << "#{ asdcp_prefix_token }_#{ ch }.wav"
+    fifo_tokens << "#{ asdcp_prefix_token }_#{ ch.to_s.rjust(2, '0') }.wav"
   end
 
   fifo_zombies = Dir.glob( "#{ asdcp_prefix_token }*" )


### PR DESCRIPTION
asdcp mounts files as "..._01" not as "..._1" on ubuntu 16/18, so this value should be changed in dcp_inspect.